### PR TITLE
Fix bug in getFileHashes on first run

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -214,12 +214,19 @@ module.exports = {
 		if (hash) {
 			actualPrefix = `${actualPrefix}:${hash}`
 		}
-		const fileHashes = await getItem({
-			key: `${prefix || ''}${hash || 'hashes'}`
-		})
-		return fileHashes
-			? JSON.parse(fileHashes)
-			: {}
+		try {
+			const fileHashes = await getItem({
+				key: `${prefix || ''}${hash || 'hashes'}`
+			})
+			return fileHashes
+				? JSON.parse(fileHashes)
+				: {}
+		} catch (err) {
+			if (err.statusCode === 404) {
+				return {}
+			}
+			throw err
+		}
 	},
 	putFileHashes: async ({ prefix, hash, hashMap }) => {
 		let actualPrefix = prefix || ''


### PR DESCRIPTION
If the `hashes` key didn't exist yet, the API request would fail with a http status 404